### PR TITLE
Added HTTPS endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@
 
 var request = require('superagent');
 
-module.exports = function(type, https) {
-  let protocol = 'http://';
-  if (https) protocol = 'https://';
+module.exports = function(type, use_http) {
+  let protocol = 'https://';
+  if (use_http) protocol = 'http://';
   
   return new Promise( (resolve, reject) => {
 

--- a/index.js
+++ b/index.js
@@ -2,11 +2,14 @@
 
 var request = require('superagent');
 
-module.exports = function(type) {
+module.exports = function(type, https) {
+  let protocol = 'http://';
+  if (https) protocol = 'https://';
+  
   return new Promise( (resolve, reject) => {
 
     request
-      .get('http://api.randomuser.me/')
+      .get(protocol + 'api.randomuser.me/')
       .end( (err, res) => {
         if (err)
           reject(err);


### PR DESCRIPTION
Modern browsers do not allow HTTP requests on HTTPS websites, and will return a Cross Origin Blocked Error.